### PR TITLE
Make sure also more recent versions of ij jar are found

### DIFF
--- a/build-mm.sh
+++ b/build-mm.sh
@@ -25,6 +25,8 @@ if [ ! -d "$IJ_DIR" ]; then
     unzip "fiji-linux64.zip"
 fi
 
+IJ_JAR=`ls -1 "${IJ_DIR}"/jars/ij-1.5*.jar`
+
 # Install dependencies (ideally everything would be managed by Maven...)
 
 mkdir -p "$THIRDPARTY_DIR/classext"
@@ -65,12 +67,12 @@ GIT_HASH=$(git rev-parse --short HEAD)
 
 ./autogen.sh
 ./configure --enable-imagej-plugin="$IJ_DIR" \
-            --with-ij-jar="$IJ_DIR/jars/ij-1.51v-SNAPSHOT.jar" \
+            --with-ij-jar="$IJ_JAR" \
             --with-boost="$BOOST_DIR" \
             LDFLAGS=-L"$BOOST_DIR/lib"
 
 make fetchdeps
-make
+make --jobs=`nproc --all`
 
 # Install Micro-Manager
 
@@ -78,7 +80,7 @@ make install
 cp "$MM_DIR/bindist/any-platform/MMConfig_demo.cfg" "$IJ_DIR"
 
 # Copy boost libraries to ImageJ folder
-cp -R "$BOOST_DIR/lib/." "$IJ_DIR"
+cp --no-dereference --recursive "${BOOST_DIR}"/lib/. "${IJ_DIR}/"
 
 cd ../
 
@@ -86,4 +88,4 @@ cd ../
 
 mkdir -p "bundles/"
 BUNDLE_NAME="$(date +"%Y.%m.%d.%H.%M").MicroManager-$GIT_HASH.zip"
-zip -r "bundles/$BUNDLE_NAME" "Fiji.app"
+zip --symlinks --recurse-paths "bundles/$BUNDLE_NAME" "Fiji.app"

--- a/build-mm.sh
+++ b/build-mm.sh
@@ -20,8 +20,7 @@ if [ ! -f "fiji-linux64.zip" ]; then
     wget "https://downloads.imagej.net/fiji/latest/fiji-linux64.zip"
 fi
 
-rm -fr "$IJ_DIR"
-if [ ! -d "$IJ_DIR" ]; then
+if [ ! -e "$IJ_DIR" ]; then
     unzip "fiji-linux64.zip"
 fi
 
@@ -45,7 +44,7 @@ fi
 # Boost shipped by Ubuntu is now to recent and does not work well with Micro-manager.
 # So we install an older version (1.57).
 
-if [ ! -d "$BOOST_DIR" ]; then
+if [ ! -e "$BOOST_DIR" ]; then
 	mkdir -p "$BOOST_DIR"
 	cd "$BOOST_DIR"
     wget "https://anaconda.org/anaconda/boost/1.57.0/download/linux-64/boost-1.57.0-4.tar.bz2"
@@ -56,12 +55,18 @@ fi
 
 # Clone the git repository
 
-if [ ! -d "$MM_DIR" ]; then
+if [ ! -e "$MM_DIR" ]; then
   git clone https://github.com/micro-manager/micro-manager.git
 fi
 
 cd "$MM_DIR"
-GIT_HASH=$(git rev-parse --short HEAD)
+if [ -d ".git" ]; then
+  VERSION_ID=$(git rev-parse --short HEAD)
+else if [ -d ".svn" ]; then
+  VERSION_ID="svn-"$(svn info --show-item=revision .)
+fi else
+  VERSION_ID=$(date +%F)
+fi
 
 # Launch the build process (it can take a while)
 
@@ -87,5 +92,5 @@ cd ../
 # Generate zip bundle for distribution and backup
 
 mkdir -p "bundles/"
-BUNDLE_NAME="$(date +"%Y.%m.%d.%H.%M").MicroManager-$GIT_HASH.zip"
+BUNDLE_NAME="$(date +"%Y.%m.%d.%H.%M").MicroManager-${VERSION_ID}.zip"
 zip --symlinks --recurse-paths "bundles/$BUNDLE_NAME" "Fiji.app"


### PR DESCRIPTION
Hi hadim,

thanks for the mm build script, helped me a lot.

I had to make some changes to get it working with the recent ij version it is downloading. You might want to have these changes too.

- Make sure also more recent versions of ij jar are found.
- Use multiple cores if available.
- Keep boost lib symlinks when copying them. Use long param format for easier understanding.


Thanks for considering my pull request

Ben